### PR TITLE
feat: enable mode-watcher to manage the theme-color meta tag

### DIFF
--- a/.changeset/witty-mangos-sip.md
+++ b/.changeset/witty-mangos-sip.md
@@ -1,0 +1,5 @@
+---
+'mode-watcher': minor
+---
+
+Allow `mode-watcher` to manage the theme-color meta tag

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -4,27 +4,27 @@ module.exports = {
 		'eslint:recommended',
 		'plugin:@typescript-eslint/recommended',
 		'plugin:svelte/recommended',
-		'prettier'
+		'prettier',
 	],
 	parser: '@typescript-eslint/parser',
 	plugins: ['@typescript-eslint'],
 	parserOptions: {
 		sourceType: 'module',
 		ecmaVersion: 2020,
-		extraFileExtensions: ['.svelte']
+		extraFileExtensions: ['.svelte'],
 	},
 	env: {
 		browser: true,
 		es2017: true,
-		node: true
+		node: true,
 	},
 	overrides: [
 		{
 			files: ['*.svelte'],
 			parser: 'svelte-eslint-parser',
 			parserOptions: {
-				parser: '@typescript-eslint/parser'
-			}
-		}
-	]
+				parser: '@typescript-eslint/parser',
+			},
+		},
+	],
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,7 @@
 {
 	"useTabs": true,
 	"singleQuote": true,
-	"trailingComma": "none",
+	"trailingComma": "es5",
 	"printWidth": 100,
 	"plugins": ["prettier-plugin-svelte"],
 	"pluginSearchDirs": ["."],

--- a/README.md
+++ b/README.md
@@ -37,6 +37,20 @@ To set a default mode, use the `defaultMode` prop:
 <ModeWatcher defaultMode={"dark"}>
 ```
 
+`ModeWatcher` can manage the `theme-color` meta tag for you.
+
+To enable this, set the `themeColor` prop to your preferred colors:
+
+```svelte
+<ModeWatcher themeColor={{ dark: "black", light: "white" }}>
+```
+
+Note that for this to work, you must have added the `theme-color` meta tag to your `head` element in `app.html`:
+
+```html
+<meta name="theme-color" content="black" />
+```
+
 ## API
 
 ### toggleMode

--- a/README.md
+++ b/README.md
@@ -47,8 +47,20 @@ To enable this, set the `themeColor` prop to your preferred colors:
 
 Note that for this to work, you must have added the `theme-color` meta tag to your `head` element in `app.html`:
 
-```html
-<meta name="theme-color" content="black" />
+```diff
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
++		<meta name="theme-color" content="black" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div>%sveltekit.body%</div>
+	</body>
+</html>
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -45,24 +45,6 @@ To enable this, set the `themeColor` prop to your preferred colors:
 <ModeWatcher themeColor={{ dark: "black", light: "white" }}>
 ```
 
-Note that for this to work, you must have added the `theme-color` meta tag to your `head` element in `app.html`:
-
-```diff
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<meta charset="utf-8" />
-+		<meta name="theme-color" content="black" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		%sveltekit.head%
-	</head>
-	<body data-sveltekit-preload-data="hover">
-		<div>%sveltekit.body%</div>
-	</body>
-</html>
-```
-
 ## API
 
 ### toggleMode

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,10 +3,10 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 const config: PlaywrightTestConfig = {
 	webServer: {
 		command: 'npm run build && npm run preview',
-		port: 4173
+		port: 4173,
 	},
 	testDir: 'tests',
-	testMatch: /(.+\.)?(test|spec)\.[jt]s/
+	testMatch: /(.+\.)?(test|spec)\.[jt]s/,
 };
 
 export default config;

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -6,8 +6,8 @@ const config = {
 		//Some plugins, like tailwindcss/nesting, need to run before Tailwind,
 		tailwindcss(),
 		//But others, like autoprefixer, need to run after,
-		autoprefixer
-	]
+		autoprefixer,
+	],
 };
 
 module.exports = config;

--- a/scripts/setupTest.ts
+++ b/scripts/setupTest.ts
@@ -9,7 +9,7 @@ import type * as stores from '$app/stores';
 import { configure } from '@testing-library/dom';
 
 configure({
-	asyncUtilTimeout: 1500
+	asyncUtilTimeout: 1500,
 });
 
 // Mock SvelteKit runtime module $app/environment
@@ -17,7 +17,7 @@ vi.mock('$app/environment', (): typeof environment => ({
 	browser: false,
 	dev: true,
 	building: false,
-	version: 'any'
+	version: 'any',
 }));
 
 // Mock SvelteKit runtime module $app/navigation
@@ -29,7 +29,7 @@ vi.mock('$app/navigation', (): typeof navigation => ({
 	invalidate: () => Promise.resolve(),
 	invalidateAll: () => Promise.resolve(),
 	preloadData: () => Promise.resolve(),
-	preloadCode: () => Promise.resolve()
+	preloadCode: () => Promise.resolve(),
 }));
 
 // Mock SvelteKit runtime module $app/stores
@@ -40,12 +40,12 @@ vi.mock('$app/stores', (): typeof stores => {
 			url: new URL('http://localhost'),
 			params: {},
 			route: {
-				id: null
+				id: null,
 			},
 			status: 200,
 			error: null,
 			data: {},
-			form: undefined
+			form: undefined,
 		});
 		const updated = { subscribe: readable(false).subscribe, check: async () => false };
 
@@ -55,30 +55,30 @@ vi.mock('$app/stores', (): typeof stores => {
 	const page: typeof stores.page = {
 		subscribe(fn) {
 			return getStores().page.subscribe(fn);
-		}
+		},
 	};
 	const navigating: typeof stores.navigating = {
 		subscribe(fn) {
 			return getStores().navigating.subscribe(fn);
-		}
+		},
 	};
 	const updated: typeof stores.updated = {
 		subscribe(fn) {
 			return getStores().updated.subscribe(fn);
 		},
-		check: async () => false
+		check: async () => false,
 	};
 
 	return {
 		getStores,
 		navigating,
 		page,
-		updated
+		updated,
 	};
 });
 
 export const mediaQueryState = {
-	matches: false
+	matches: false,
 };
 
 const listeners: ((event: unknown) => void)[] = [];
@@ -107,10 +107,10 @@ Object.defineProperty(window, 'matchMedia', {
 				for (const callback of listeners) {
 					callback({
 						matches: mediaQueryState.matches,
-						media: '(prefers-color-scheme: light)'
+						media: '(prefers-color-scheme: light)',
 					});
 				}
 			}
-		})
-	}))
+		}),
+	})),
 });

--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<meta name="theme-color" content="black" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%

--- a/src/app.html
+++ b/src/app.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
+		<meta name="theme-color" content="black" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,7 +5,7 @@ import {
 	mode,
 	setMode,
 	toggleMode,
-	resetMode
+	resetMode,
 } from './mode.js';
 
 export {
@@ -15,7 +15,7 @@ export {
 	localStorageKey,
 	userPrefersMode,
 	systemPrefersMode,
-	mode
+	mode,
 };
 
 export { default as ModeWatcher } from './mode-watcher.svelte';

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,7 +6,7 @@ import {
 	setMode,
 	toggleMode,
 	resetMode
-} from './mode';
+} from './mode.js';
 
 export {
 	setMode,

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -7,11 +7,12 @@
 		mode,
 		themeColors as themeColorsStore
 	} from './mode.js';
+	import type { Mode, ThemeColors } from './types.js';
 
 	export let track = true;
-	export let defaultMode: 'light' | 'dark' | 'system' = 'system';
+	export let defaultMode: Mode = 'system';
 	// TODO: how can I pass this prop to stores in stores.ts BEFORE they are initialized??
-	export let themeColors: { dark: string; light: string } | undefined = undefined;
+	export let themeColors: ThemeColors = undefined;
 
 	themeColorsStore.set(themeColors);
 
@@ -26,23 +27,23 @@
 		};
 	});
 
-	function setInitialMode(
-		defaultMode: 'light' | 'dark' | 'system',
-		themeColors?: { dark: string; light: string }
-	) {
-		const elem = document.documentElement,
-			mode = localStorage.getItem('mode') || defaultMode,
-			light =
-				mode === 'light' ||
-				(mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
+	function setInitialMode(defaultMode: Mode, themeColors?: ThemeColors) {
+		const rootEl = document.documentElement;
+		const mode = localStorage.getItem('mode') || defaultMode;
+		const light =
+			mode === 'light' ||
+			(mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
 
-		elem.classList[light ? 'remove' : 'add']('dark');
-		elem.style.colorScheme = light ? 'light' : 'dark';
+		rootEl.classList[light ? 'remove' : 'add']('dark');
+		rootEl.style.colorScheme = light ? 'light' : 'dark';
 
 		if (themeColors) {
-			const te = document.querySelector('meta[name="theme-color"]');
-			if (te) {
-				te.setAttribute('content', mode === 'light' ? themeColors.light : themeColors.dark);
+			const themeMetaEl = document.querySelector('meta[name="theme-color"]');
+			if (themeMetaEl) {
+				themeMetaEl.setAttribute(
+					'content',
+					mode === 'light' ? themeColors.light : themeColors.dark
+				);
 			}
 		}
 

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { systemPrefersMode, setMode, localStorageKey, mode } from './mode';
+	import {
+		systemPrefersMode,
+		setMode,
+		localStorageKey,
+		mode,
+		themeColors as themeColorsStore
+	} from './mode.js';
 
 	export let track = true;
 	export let defaultMode: 'light' | 'dark' | 'system' = 'system';
 	// TODO: how can I pass this prop to stores in stores.ts BEFORE they are initialized??
 	export let themeColors: { dark: string; light: string } | undefined = undefined;
+
+	themeColorsStore.set(themeColors);
 
 	onMount(() => {
 		const unsubscriber = mode.subscribe(() => {});

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -4,6 +4,7 @@
 
 	export let track = true;
 	export let defaultMode: 'light' | 'dark' | 'system' = 'system';
+	// TODO: how can I pass this prop to stores.ts BEFORE they are initialized??
 	export let themeColors: { dark: string; light: string } | undefined = undefined;
 
 	onMount(() => {

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -54,6 +54,12 @@
 </script>
 
 <svelte:head>
+	{#if themeColors}
+		<!-- default to dark mode for to allow testing -->
+		<!-- this will be overwritten by FOUC prevention snippet below -->
+		<!-- but that snippet does not run in vitest -->
+		<meta name="theme-color" content={themeColors.dark} />
+	{/if}
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
 	{@html `<script nonce="%sveltekit.nonce%">(` + stringified + `)(` + args + `);</script>`}
 </svelte:head>

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -11,7 +11,6 @@
 
 	export let track = true;
 	export let defaultMode: Mode = 'system';
-	// TODO: how can I pass this prop to stores in stores.ts BEFORE they are initialized??
 	export let themeColors: ThemeColors = undefined;
 
 	themeColorsStore.set(themeColors);
@@ -20,7 +19,7 @@
 		const unsubscriber = mode.subscribe(() => {});
 		systemPrefersMode.tracking(track);
 		systemPrefersMode.query();
-		setMode((localStorage.getItem(localStorageKey) as 'dark' | 'light' | 'system') || defaultMode);
+		setMode((localStorage.getItem(localStorageKey) as Mode) || defaultMode);
 
 		return () => {
 			unsubscriber();
@@ -29,7 +28,7 @@
 
 	function setInitialMode(defaultMode: Mode, themeColors?: ThemeColors) {
 		const rootEl = document.documentElement;
-		const mode = localStorage.getItem('mode') || defaultMode;
+		const mode = localStorage.getItem('mode-watcher-mode') || defaultMode;
 		const light =
 			mode === 'light' ||
 			(mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -4,7 +4,7 @@
 
 	export let track = true;
 	export let defaultMode: 'light' | 'dark' | 'system' = 'system';
-	// TODO: how can I pass this prop to stores.ts BEFORE they are initialized??
+	// TODO: how can I pass this prop to stores in stores.ts BEFORE they are initialized??
 	export let themeColors: { dark: string; light: string } | undefined = undefined;
 
 	onMount(() => {

--- a/src/lib/mode-watcher.svelte
+++ b/src/lib/mode-watcher.svelte
@@ -4,6 +4,7 @@
 
 	export let track = true;
 	export let defaultMode: 'light' | 'dark' | 'system' = 'system';
+	export let themeColors: { dark: string; light: string } | undefined = undefined;
 
 	onMount(() => {
 		const unsubscriber = mode.subscribe(() => {});
@@ -16,22 +17,34 @@
 		};
 	});
 
-	function setInitialMode() {
+	function setInitialMode(
+		defaultMode: 'light' | 'dark' | 'system',
+		themeColors?: { dark: string; light: string }
+	) {
 		const elem = document.documentElement,
-			mode = localStorage.getItem('mode') || '<DEFAULT_MODE>',
+			mode = localStorage.getItem('mode') || defaultMode,
 			light =
 				mode === 'light' ||
 				(mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
 
 		elem.classList[light ? 'remove' : 'add']('dark');
 		elem.style.colorScheme = light ? 'light' : 'dark';
+
+		if (themeColors) {
+			const te = document.querySelector('meta[name="theme-color"]');
+			if (te) {
+				te.setAttribute('content', mode === 'light' ? themeColors.light : themeColors.dark);
+			}
+		}
+
 		localStorage.setItem('mode', mode);
 	}
 
-	const stringified = setInitialMode.toString().replace('<DEFAULT_MODE>', defaultMode);
+	const args = `"${defaultMode}"${themeColors ? `, ${JSON.stringify(themeColors)}` : ''}`;
+	const stringified = setInitialMode.toString();
 </script>
 
 <svelte:head>
 	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
-	{@html `<script nonce="%sveltekit.nonce%">(` + stringified + `)();</script>`}
+	{@html `<script nonce="%sveltekit.nonce%">(` + stringified + `)(` + args + `);</script>`}
 </svelte:head>

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -6,6 +6,7 @@ import {
 	derivedMode,
 	themeColors
 } from './stores.js';
+import type { Mode } from './types.js';
 
 /** Toggle between light and dark mode */
 export function toggleMode(): void {
@@ -13,7 +14,7 @@ export function toggleMode(): void {
 }
 
 /** Set the mode to light or dark */
-export function setMode(mode: 'dark' | 'light' | 'system'): void {
+export function setMode(mode: Mode): void {
 	userPrefersMode.set(mode);
 }
 

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -1,5 +1,11 @@
 import { get } from 'svelte/store';
-import { localStorageKey, userPrefersMode, systemPrefersMode, derivedMode } from './stores';
+import {
+	localStorageKey,
+	userPrefersMode,
+	systemPrefersMode,
+	derivedMode,
+	themeColors
+} from './stores.js';
 
 /** Toggle between light and dark mode */
 export function toggleMode(): void {
@@ -16,4 +22,4 @@ export function resetMode(): void {
 	userPrefersMode.set('system');
 }
 
-export { localStorageKey, userPrefersMode, systemPrefersMode, derivedMode as mode };
+export { localStorageKey, userPrefersMode, systemPrefersMode, derivedMode as mode, themeColors };

--- a/src/lib/mode.ts
+++ b/src/lib/mode.ts
@@ -4,9 +4,9 @@ import {
 	userPrefersMode,
 	systemPrefersMode,
 	derivedMode,
-	themeColors
+	themeColors,
 } from './stores.js';
-import type { Mode } from './types.js';
+import type { Mode, ThemeColors } from './types.js';
 
 /** Toggle between light and dark mode */
 export function toggleMode(): void {
@@ -21,6 +21,26 @@ export function setMode(mode: Mode): void {
 /** Reset the mode to operating system preference */
 export function resetMode(): void {
 	userPrefersMode.set('system');
+}
+
+export function setInitialMode(defaultMode: Mode, themeColors?: ThemeColors) {
+	const rootEl = document.documentElement;
+	const mode = localStorage.getItem('mode-watcher-mode') || defaultMode;
+	const light =
+		mode === 'light' ||
+		(mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
+
+	rootEl.classList[light ? 'remove' : 'add']('dark');
+	rootEl.style.colorScheme = light ? 'light' : 'dark';
+
+	if (themeColors) {
+		const themeMetaEl = document.querySelector('meta[name="theme-color"]');
+		if (themeMetaEl) {
+			themeMetaEl.setAttribute('content', mode === 'light' ? themeColors.light : themeColors.dark);
+		}
+	}
+
+	localStorage.setItem('mode', mode);
 }
 
 export { localStorageKey, userPrefersMode, systemPrefersMode, derivedMode as mode, themeColors };

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,6 @@
 import { writable, derived } from 'svelte/store';
-import { withoutTransition } from './without-transition';
+import { withoutTransition } from './without-transition.js';
+import type { ThemeColors } from './types.js';
 
 // saves having to branch for server vs client
 const noopStorage = {
@@ -24,6 +25,10 @@ export const userPrefersMode = createUserPrefersMode();
  * Readable store that represents the system's preferred mode (`"dark"`, `"light"` or `undefined`)
  */
 export const systemPrefersMode = createSystemMode();
+/**
+ * Theme colors for light and dark modes.
+ */
+export const themeColors = writable<ThemeColors>(undefined);
 /**
  * Derived store that represents the current mode (`"dark"`, `"light"` or `undefined`)
  */
@@ -102,8 +107,8 @@ function createSystemMode() {
 
 function createDerivedMode() {
 	const { subscribe } = derived(
-		[userPrefersMode, systemPrefersMode],
-		([$userPrefersMode, $systemPrefersMode]) => {
+		[userPrefersMode, systemPrefersMode, themeColors],
+		([$userPrefersMode, $systemPrefersMode, $themeColors]) => {
 			if (!isBrowser) return undefined;
 
 			const derivedMode = $userPrefersMode === 'system' ? $systemPrefersMode : $userPrefersMode;
@@ -114,16 +119,14 @@ function createDerivedMode() {
 				if (derivedMode === 'light') {
 					htmlEl.classList.remove('dark');
 					htmlEl.style.colorScheme = 'light';
-					if (themeColorEl) {
-						// TODO: how do I get the themeColors prop?
-						// themeColorEl.setAttribute('content', themeColors.light);
+					if (themeColorEl && $themeColors) {
+						themeColorEl.setAttribute('content', $themeColors.light);
 					}
 				} else {
 					htmlEl.classList.add('dark');
 					htmlEl.style.colorScheme = 'dark';
-					if (themeColorEl) {
-						// TODO: how do I get the themeColors prop?
-						// themeColorEl.setAttribute('content', themeColors.dark);
+					if (themeColorEl && $themeColors) {
+						themeColorEl.setAttribute('content', $themeColors.dark);
 					}
 				}
 			});

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -115,14 +115,14 @@ function createDerivedMode() {
 					htmlEl.classList.remove('dark');
 					htmlEl.style.colorScheme = 'light';
 					if (themeColorEl) {
-						// TODO: how do I get the themeColor prop?
+						// TODO: how do I get the themeColors prop?
 						// themeColorEl.setAttribute('content', themeColors.light);
 					}
 				} else {
 					htmlEl.classList.add('dark');
 					htmlEl.style.colorScheme = 'dark';
 					if (themeColorEl) {
-						// TODO: how do I get the themeColor prop?
+						// TODO: how do I get the themeColors prop?
 						// themeColorEl.setAttribute('content', themeColors.dark);
 					}
 				}

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -110,12 +110,21 @@ function createDerivedMode() {
 
 			withoutTransition(() => {
 				const htmlEl = document.documentElement;
+				const themeColorEl = document.querySelector('meta[name="theme-color"]');
 				if (derivedMode === 'light') {
 					htmlEl.classList.remove('dark');
 					htmlEl.style.colorScheme = 'light';
+					if (themeColorEl) {
+						// TODO: how do I get the themeColor prop?
+						// themeColorEl.setAttribute('content', themeColors.light);
+					}
 				} else {
 					htmlEl.classList.add('dark');
 					htmlEl.style.colorScheme = 'dark';
+					if (themeColorEl) {
+						// TODO: how do I get the themeColor prop?
+						// themeColorEl.setAttribute('content', themeColors.dark);
+					}
 				}
 			});
 

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -7,7 +7,7 @@ const noopStorage = {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	getItem: (_key: string) => null,
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	setItem: (_key: string, _value: string) => {}
+	setItem: (_key: string, _value: string) => {},
 };
 
 // whether we are running on server vs client
@@ -68,7 +68,7 @@ function createUserPrefersMode() {
 
 	return {
 		subscribe,
-		set
+		set,
 	};
 }
 
@@ -108,7 +108,7 @@ function createSystemMode() {
 	return {
 		subscribe,
 		query,
-		tracking
+		tracking,
 	};
 }
 
@@ -143,10 +143,11 @@ function createDerivedMode() {
 	);
 
 	return {
-		subscribe
+		subscribe,
 	};
 }
 
-function isValidMode(value: unknown): value is Mode {
+export function isValidMode(value: unknown): value is Mode {
+	if (typeof value !== 'string') return false;
 	return modes.includes(value as Mode);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,1 @@
+export type ThemeColors = { dark: string; light: string } | undefined

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,1 +1,4 @@
+import type { modes } from './stores';
+
+export type Mode = typeof modes[number];
 export type ThemeColors = { dark: string; light: string } | undefined;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,1 +1,1 @@
-export type ThemeColors = { dark: string; light: string } | undefined
+export type ThemeColors = { dark: string; light: string } | undefined;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,5 +3,5 @@
 	import ModeWatcher from '$lib/mode-watcher.svelte';
 </script>
 
-<ModeWatcher />
+<ModeWatcher themeColors={{ dark: 'black', light: 'white' }} />
 <slot />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,6 @@
 				return themeColorElement.outerHTML;
 			}
 		}
-		return undefined;
 	});
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,11 +1,41 @@
 <script lang="ts">
 	import { toggleMode, setMode, resetMode, userPrefersMode, systemPrefersMode, mode } from '$lib';
+
+	import { derived } from 'svelte/store';
+	import { browser } from '$app/environment';
+
+	const htmlElement = derived(mode, () => {
+		if (browser) {
+			const htmlElement = document.documentElement;
+			if (htmlElement) {
+				return htmlElement.outerHTML.replace(htmlElement.innerHTML + '</html>', '');
+			}
+		}
+	});
+
+	const themeColorElement = derived(mode, () => {
+		if (browser) {
+			const themeColorElement = document.querySelector('meta[name="theme-color"]');
+			if (themeColorElement) {
+				return themeColorElement.outerHTML;
+			}
+		}
+		return undefined;
+	});
 </script>
 
 <div class="container py-12 space-y-4">
 	<p>User prefers mode: {$userPrefersMode}</p>
 	<p>System prefers mode: {$systemPrefersMode}</p>
 	<p>Current mode: {$mode}</p>
+
+	{#if $htmlElement !== undefined}
+		<pre>{$htmlElement}</pre>
+	{/if}
+	{#if $themeColorElement !== undefined}
+		<pre>{$themeColorElement}</pre>
+	{/if}
+
 	<button on:click={toggleMode}> Toggle </button>
 	<button on:click={() => setMode('light')}> Light Mode </button>
 	<button on:click={() => setMode('dark')}> Dark Mode </button>

--- a/src/tests/Mode.svelte
+++ b/src/tests/Mode.svelte
@@ -4,10 +4,6 @@
 	export let track = true;
 </script>
 
-<svelte:head>
-	<meta name="theme-color" content="black" />
-</svelte:head>
-
 <ModeWatcher {track} themeColors={{ dark: 'black', light: 'white' }} />
 <span data-testid="mode">{$mode}</span>
 <button on:click={toggleMode} data-testid="toggle"> toggle </button>

--- a/src/tests/Mode.svelte
+++ b/src/tests/Mode.svelte
@@ -4,7 +4,11 @@
 	export let track = true;
 </script>
 
-<ModeWatcher {track} />
+<svelte:head>
+	<meta name="theme-color" content="black" />
+</svelte:head>
+
+<ModeWatcher {track} themeColors={{ dark: 'black', light: 'white' }} />
 <span data-testid="mode">{$mode}</span>
 <button on:click={toggleMode} data-testid="toggle"> toggle </button>
 <button on:click={() => setMode('light')} data-testid="light">light</button>

--- a/src/tests/StealthMode.svelte
+++ b/src/tests/StealthMode.svelte
@@ -4,7 +4,11 @@
 	export let track = true;
 </script>
 
-<ModeWatcher {track} />
+<svelte:head>
+	<meta name="theme-color" content="black" />
+</svelte:head>
+
+<ModeWatcher {track} themeColors={{ dark: 'black', light: 'white' }} />
 <button on:click={toggleMode} data-testid="toggle"> toggle </button>
 <button on:click={() => setMode('light')} data-testid="light">light</button>
 <button on:click={() => setMode('dark')} data-testid="dark">dark</button>

--- a/src/tests/StealthMode.svelte
+++ b/src/tests/StealthMode.svelte
@@ -4,10 +4,6 @@
 	export let track = true;
 </script>
 
-<svelte:head>
-	<meta name="theme-color" content="black" />
-</svelte:head>
-
 <ModeWatcher {track} themeColors={{ dark: 'black', light: 'white' }} />
 <button on:click={toggleMode} data-testid="toggle"> toggle </button>
 <button on:click={() => setMode('light')} data-testid="light">light</button>

--- a/src/tests/mode.spec.ts
+++ b/src/tests/mode.spec.ts
@@ -19,19 +19,25 @@ it('toggles the mode', async () => {
 
 	const classes = getClasses(rootEl);
 	const colorScheme = getColorScheme(rootEl);
+	const themeColor = getThemeColor(rootEl);
 	expect(classes).toContain('dark');
 	expect(colorScheme).toBe('dark');
+	expect(themeColor).toBe('black');
 	const toggle = getByTestId('toggle');
 	await userEvent.click(toggle);
 	const classes2 = getClasses(rootEl);
 	const colorScheme2 = getColorScheme(rootEl);
+	const themeColor2 = getThemeColor(rootEl);
 	expect(classes2).not.toContain('dark');
 	expect(colorScheme2).toBe('light');
+	expect(themeColor2).toBe('white');
 	await userEvent.click(toggle);
 	const classes3 = getClasses(rootEl);
 	const colorScheme3 = getColorScheme(rootEl);
+	const themeColor3 = getThemeColor(rootEl);
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
+	expect(themeColor3).toBe('black');
 });
 
 it('allows the user to set the mode', async () => {
@@ -39,21 +45,27 @@ it('allows the user to set the mode', async () => {
 	const rootEl = container.parentElement;
 	const classes = getClasses(rootEl);
 	const colorScheme = getColorScheme(rootEl);
+	const themeColor = getThemeColor(rootEl);
 	expect(classes).toContain('dark');
 	expect(colorScheme).toBe('dark');
+	expect(themeColor).toBe('black');
 	const light = getByTestId('light');
 	await userEvent.click(light);
 	const classes2 = getClasses(rootEl);
 	const colorScheme2 = getColorScheme(rootEl);
+	const themeColor2 = getThemeColor(rootEl);
 	expect(classes2).not.toContain('dark');
 	expect(colorScheme2).toBe('light');
+	expect(themeColor2).toBe('white');
 
 	const dark = getByTestId('dark');
 	await userEvent.click(dark);
 	const classes3 = getClasses(rootEl);
 	const colorScheme3 = getColorScheme(rootEl);
+	const themeColor3 = getThemeColor(rootEl);
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
+	expect(themeColor3).toBe('black');
 });
 
 it('keeps the mode store in sync with current mode', async () => {
@@ -64,22 +76,28 @@ it('keeps the mode store in sync with current mode', async () => {
 	const mode = getByTestId('mode');
 	const classes = getClasses(rootEl);
 	const colorScheme = getColorScheme(rootEl);
+	const themeColor = getThemeColor(rootEl);
 	expect(classes).toContain('dark');
 	expect(colorScheme).toBe('dark');
+	expect(themeColor).toBe('black');
 	expect(mode.textContent).toBe('dark');
 
 	await userEvent.click(light);
 	const classes2 = getClasses(rootEl);
 	const colorScheme2 = getColorScheme(rootEl);
+	const themeColor2 = getThemeColor(rootEl);
 	expect(classes2).not.toContain('dark');
 	expect(colorScheme2).toBe('light');
+	expect(themeColor2).toBe('white');
 	expect(mode.textContent).toBe('light');
 
 	await userEvent.click(dark);
 	const classes3 = getClasses(rootEl);
 	const colorScheme3 = getColorScheme(rootEl);
+	const themeColor3 = getThemeColor(rootEl);
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
+	expect(themeColor3).toBe('black');
 	expect(mode.textContent).toBe('dark');
 });
 
@@ -91,22 +109,28 @@ it('resets the mode to system preferences', async () => {
 	const mode = getByTestId('mode');
 	const classes = getClasses(rootEl);
 	const colorScheme = getColorScheme(rootEl);
+	const themeColor = getThemeColor(rootEl);
 	expect(classes).toContain('dark');
 	expect(colorScheme).toBe('dark');
+	expect(themeColor).toBe('black');
 	expect(mode.textContent).toBe('dark');
 
 	await userEvent.click(light);
 	const classes2 = getClasses(rootEl);
 	const colorScheme2 = getColorScheme(rootEl);
+	const themeColor2 = getThemeColor(rootEl);
 	expect(classes2).not.toContain('dark');
 	expect(colorScheme2).toBe('light');
+	expect(themeColor2).toBe('white');
 	expect(mode.textContent).toBe('light');
 
 	await userEvent.click(reset);
 	const classes3 = getClasses(rootEl);
 	const colorScheme3 = getColorScheme(rootEl);
+	const themeColor3 = getThemeColor(rootEl);
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
+	expect(themeColor3).toBe('black');
 	expect(mode.textContent).toBe('dark');
 });
 
@@ -116,8 +140,10 @@ it('tracks changes to system preferences', async () => {
 	const mode = getByTestId('mode');
 	const classes = getClasses(rootEl);
 	const colorScheme = getColorScheme(rootEl);
+	const themeColor = getThemeColor(rootEl);
 	expect(classes).toContain('dark');
 	expect(colorScheme).toBe('dark');
+	expect(themeColor).toBe('black');
 	expect(mode.textContent).toBe('dark');
 
 	mediaQueryState.matches = true;
@@ -126,8 +152,10 @@ it('tracks changes to system preferences', async () => {
 	await tick();
 	const classes2 = getClasses(rootEl);
 	const colorScheme2 = getColorScheme(rootEl);
+	const themeColor2 = getThemeColor(rootEl);
 	expect(classes2).not.toContain('dark');
 	expect(colorScheme2).toBe('light');
+	expect(themeColor2).toBe('white');
 	expect(mode.textContent).toBe('light');
 
 	mediaQueryState.matches = false;
@@ -135,8 +163,10 @@ it('tracks changes to system preferences', async () => {
 	await tick();
 	const classes3 = getClasses(rootEl);
 	const colorScheme3 = getColorScheme(rootEl);
+	const themeColor3 = getThemeColor(rootEl);
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
+	expect(themeColor3).toBe('black');
 	expect(mode.textContent).toBe('dark');
 });
 
@@ -148,8 +178,10 @@ it('stops tracking changes to system preferences when user sets a mode', async (
 	const mode = getByTestId('mode');
 	const classes = getClasses(rootEl);
 	const colorScheme = getColorScheme(rootEl);
+	const themeColor = getThemeColor(rootEl);
 	expect(classes).toContain('dark');
 	expect(colorScheme).toBe('dark');
+	expect(themeColor).toBe('black');
 	expect(mode.textContent).toBe('dark');
 
 	mediaQueryState.matches = true;
@@ -158,8 +190,10 @@ it('stops tracking changes to system preferences when user sets a mode', async (
 	await tick();
 	const classes2 = getClasses(rootEl);
 	const colorScheme2 = getColorScheme(rootEl);
+	const themeColor2 = getThemeColor(rootEl);
 	expect(classes2).not.toContain('dark');
 	expect(colorScheme2).toBe('light');
+	expect(themeColor2).toBe('white');
 	expect(mode.textContent).toBe('light');
 
 	mediaQueryState.matches = false;
@@ -167,15 +201,19 @@ it('stops tracking changes to system preferences when user sets a mode', async (
 	await tick();
 	const classes3 = getClasses(rootEl);
 	const colorScheme3 = getColorScheme(rootEl);
+	const themeColor3 = getThemeColor(rootEl);
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
+	expect(themeColor3).toBe('black');
 	expect(mode.textContent).toBe('dark');
 
 	await userEvent.click(light);
 	const classes4 = getClasses(rootEl);
 	const colorScheme4 = getColorScheme(rootEl);
+	const themeColor4 = getThemeColor(rootEl);
 	expect(classes4).not.toContain('dark');
 	expect(colorScheme4).toBe('light');
+	expect(themeColor4).toBe('white');
 	expect(mode.textContent).toBe('light');
 
 	mediaQueryState.matches = true;
@@ -183,8 +221,10 @@ it('stops tracking changes to system preferences when user sets a mode', async (
 	await tick();
 	const classes5 = getClasses(rootEl);
 	const colorScheme5 = getColorScheme(rootEl);
+	const themeColor5 = getThemeColor(rootEl);
 	expect(classes5).not.toContain('dark');
 	expect(colorScheme5).toBe('light');
+	expect(themeColor5).toBe('white');
 	expect(mode.textContent).toBe('light');
 
 	mediaQueryState.matches = false;
@@ -192,15 +232,19 @@ it('stops tracking changes to system preferences when user sets a mode', async (
 	await tick();
 	const classes6 = getClasses(rootEl);
 	const colorScheme6 = getColorScheme(rootEl);
+	const themeColor6 = getThemeColor(rootEl);
 	expect(classes6).not.toContain('dark');
 	expect(colorScheme6).toBe('light');
+	expect(themeColor6).toBe('white');
 	expect(mode.textContent).toBe('light');
 
 	await userEvent.click(reset);
 	const classes7 = getClasses(rootEl);
 	const colorScheme7 = getColorScheme(rootEl);
+	const themeColor7 = getThemeColor(rootEl);
 	expect(classes7).toContain('dark');
 	expect(colorScheme7).toBe('dark');
+	expect(themeColor7).toBe('black');
 	expect(mode.textContent).toBe('dark');
 });
 
@@ -210,8 +254,10 @@ it('does not track changes to system preference when track prop is set to false'
 	const mode = getByTestId('mode');
 	const classes = getClasses(rootEl);
 	const colorScheme = getColorScheme(rootEl);
+	const themeColor = getThemeColor(rootEl);
 	expect(classes).toContain('dark');
 	expect(colorScheme).toBe('dark');
+	expect(themeColor).toBe('black');
 	expect(mode.textContent).toBe('dark');
 
 	mediaQueryState.matches = true;
@@ -220,8 +266,10 @@ it('does not track changes to system preference when track prop is set to false'
 	await tick();
 	const classes2 = getClasses(rootEl);
 	const colorScheme2 = getColorScheme(rootEl);
+	const themeColor2 = getThemeColor(rootEl);
 	expect(classes2).toContain('dark');
 	expect(colorScheme2).toBe('dark');
+	expect(themeColor2).toBe('black');
 	expect(mode.textContent).toBe('dark');
 
 	mediaQueryState.matches = false;
@@ -229,8 +277,10 @@ it('does not track changes to system preference when track prop is set to false'
 	await tick();
 	const classes3 = getClasses(rootEl);
 	const colorScheme3 = getColorScheme(rootEl);
+	const themeColor3 = getThemeColor(rootEl);
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
+	expect(themeColor3).toBe('black');
 	expect(mode.textContent).toBe('dark');
 });
 
@@ -240,19 +290,25 @@ it('also works when $mode is not used in the current page', async () => {
 
 	const classes = getClasses(rootEl);
 	const colorScheme = getColorScheme(rootEl);
+	const themeColor = getThemeColor(rootEl);
 	expect(classes).toContain('dark');
 	expect(colorScheme).toBe('dark');
+	expect(themeColor).toBe('black');
 	const toggle = getByTestId('toggle');
 	await userEvent.click(toggle);
 	const classes2 = getClasses(rootEl);
 	const colorScheme2 = getColorScheme(rootEl);
+	const themeColor2 = getThemeColor(rootEl);
 	expect(classes2).not.toContain('dark');
 	expect(colorScheme2).toBe('light');
+	expect(themeColor2).toBe('white');
 	await userEvent.click(toggle);
 	const classes3 = getClasses(rootEl);
 	const colorScheme3 = getColorScheme(rootEl);
+	const themeColor3 = getThemeColor(rootEl);
 	expect(classes3).toContain('dark');
 	expect(colorScheme3).toBe('dark');
+	expect(themeColor3).toBe('black');
 });
 
 function getClasses(element: HTMLElement | null): string[] {
@@ -268,4 +324,22 @@ function getColorScheme(element: HTMLElement | null) {
 		return '';
 	}
 	return element.style.colorScheme;
+}
+
+function getThemeColor(element: HTMLElement | null) {
+	if (element === null) {
+		return '';
+	}
+
+	const themeMetaEl = element.querySelector('meta[name="theme-color"]');
+	if (themeMetaEl === null) {
+		return '';
+	}
+
+	const content = themeMetaEl.getAttribute('content');
+	if (content === null) {
+		return '';
+	}
+
+	return content;
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -11,8 +11,8 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
-	}
+		adapter: adapter(),
+	},
 };
 
 export default config;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -6,8 +6,8 @@ const config = {
 			center: true,
 			padding: '2rem',
 			screens: {
-				'2xl': '1400px'
-			}
+				'2xl': '1400px',
+			},
 		},
 		extend: {
 			colors: {
@@ -18,42 +18,42 @@ const config = {
 				foreground: 'hsl(var(--foreground))',
 				primary: {
 					DEFAULT: 'hsl(var(--primary))',
-					foreground: 'hsl(var(--primary-foreground))'
+					foreground: 'hsl(var(--primary-foreground))',
 				},
 				secondary: {
 					DEFAULT: 'hsl(var(--secondary))',
-					foreground: 'hsl(var(--secondary-foreground))'
+					foreground: 'hsl(var(--secondary-foreground))',
 				},
 				destructive: {
 					DEFAULT: 'hsl(var(--destructive) / <alpha-value>)',
-					foreground: 'hsl(var(--destructive-foreground) / <alpha-value>)'
+					foreground: 'hsl(var(--destructive-foreground) / <alpha-value>)',
 				},
 				muted: {
 					DEFAULT: 'hsl(var(--muted))',
-					foreground: 'hsl(var(--muted-foreground))'
+					foreground: 'hsl(var(--muted-foreground))',
 				},
 				accent: {
 					DEFAULT: 'hsl(var(--accent))',
-					foreground: 'hsl(var(--accent-foreground))'
+					foreground: 'hsl(var(--accent-foreground))',
 				},
 				popover: {
 					DEFAULT: 'hsl(var(--popover))',
-					foreground: 'hsl(var(--popover-foreground))'
+					foreground: 'hsl(var(--popover-foreground))',
 				},
 				card: {
 					DEFAULT: 'hsl(var(--card))',
-					foreground: 'hsl(var(--card-foreground))'
-				}
+					foreground: 'hsl(var(--card-foreground))',
+				},
 			},
 			borderRadius: {
 				xl: `calc(var(--radius) + 4px)`,
 				lg: `var(--radius)`,
 				md: `calc(var(--radius) - 2px)`,
-				sm: 'calc(var(--radius) - 4px)'
-			}
+				sm: 'calc(var(--radius) - 4px)',
+			},
 		},
-		plugins: []
-	}
+		plugins: [],
+	},
 };
 
 module.exports = config;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
 		setupFiles: ['./scripts/setupTest.ts'],
 		// Exclude files in v8
 		coverage: {
-			exclude: ['setupTest.ts']
+			exclude: ['setupTest.ts'],
 		},
-		alias: [{ find: /^svelte$/, replacement: 'svelte/internal' }]
-	}
+		alias: [{ find: /^svelte$/, replacement: 'svelte/internal' }],
+	},
 });


### PR DESCRIPTION
closes #40.

**progress:**
- refactored how variables are passed into the FOUC prevention snippet in `src/lib/mode-watcher.svelte`. FOUC prevention snippet should work based on my testing - both for existing functionality and for the `theme-color` setting
- improved demo app: `src/routes/+page.svelte` by adding derived stores that displays how the `html` element and the new `meta` element is updated
- added `themeColors` prop in the demo app: `src/routes/+layout.svelte`
- added pre-existing `<meta name="theme-color" content="..." />` in `src/app.html` for the demo app, see below

**todo:**
- [x] right now, based on the existing code in #40, this requires an existing `<meta name="theme-color" content="..." />` entry since we check for it's existing before overwriting it. is this intentional or should we always write (create a meta element for theme-color if needed) if `themeColors` are set?
- [x] **the big one:** I could not figure out how to pass props from the component to the stores, see TODOs in `src/lib/stores.ts`. could you help me out here @huntabyte - I'm searching for some pattern where props passed to a component could somehow be read from stores which are initialised somewhere else... do we perhaps need to add some helper function for creating stores/components? use `context="module"`? I'm not sure, I have not encountered this before
- [x] tests, when/if the two above are resolved
- [x] changeset, when/if the all of the above are resolved