### PR TITLE
chore: add repro redirect link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: [huntabyte]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: ollema
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/.github/ISSUE_TEMPLATE/1-documentation_change.yml
+++ b/.github/ISSUE_TEMPLATE/1-documentation_change.yml
@@ -1,0 +1,22 @@
+name: Report Docs Issue
+description: Suggest an addition or modification to the documentation
+labels: ["documentation"]
+body:
+  - type: dropdown
+    attributes:
+      label: Change Type
+      description: What type of change are you proposing?
+      options:
+        - Addition
+        - Correction
+        - Removal
+        - Cleanup (formatting, typos, etc.)
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed Changes
+      description: Describe the proposed changes and why they are necessary
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -1,0 +1,24 @@
+name: 🛠️ Request New Feature
+description: Let us know what you would like to see added.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature in detail (code, mocks, or screenshots encouraged)
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: What type of pull request would this be?
+      options:
+        - "New Feature"
+        - "Enhancement"
+        - "Guide"
+        - "Docs"
+        - "Other"
+  - type: textarea
+    id: references
+    attributes:
+      label: Provide relevant links or additional information.

--- a/.github/ISSUE_TEMPLATE/3-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug_report.yml
@@ -1,0 +1,53 @@
+name: "🐛 Bug report"
+description: Report an issue with mode-watcher
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is. If you intend to submit a PR for this issue, tell us how in the description. Thanks!
+      placeholder: Bug description
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: |
+        Please provide a link to a repo or Stackblitz that can reproduce the problem you ran into. If a report is vague (e.g. just a generic error message) and has no reproduction, it will receive a "needs reproduction" label. If no reproduction is provided within a reasonable time-frame, the issue will be closed.
+      
+        To get started, you can use the following StackBlitz template:
+        https://mode-watcher.svecosystem.com/repro
+      placeholder: Reproduction
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: "Please include browser console and server logs around the time this bug occurred. Optional if provided reproduction. Please try not to insert an image but copy paste the log text."
+      render: bash
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: Output of `npx envinfo --system --npmPackages svelte,mode-watcher,@sveltejs/kit --binaries --browsers`
+      render: bash
+      placeholder: System, Binaries, Browsers
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: Select the severity of this issue
+      options:
+        - annoyance
+        - blocking an upgrade
+        - blocking all usage of mode-watcher
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Get Help
+    url: https://github.com/huntabyte/mode-watcher/discussions/new?category=help
+    about: If you can't get something to work the way you expect, open a question in our discussion forums.
+  - name: Discord
+    url: https://discord.gg/rePvPCE9dh
+    about: If you need to have a back-and-forth conversation, join the Discord server.

--- a/sites/docs/src/routes/repro/+page.ts
+++ b/sites/docs/src/routes/repro/+page.ts
@@ -1,0 +1,6 @@
+import { redirect } from "@sveltejs/kit";
+import type { PageLoad } from "./$types";
+
+export const load: PageLoad = async () => {
+	redirect(303, "https://stackblitz.com/github/svecosystem/mode-watcher-reproduction");
+};


### PR DESCRIPTION
Users can head straight to https://mode-watcher.svecosystem.com/repro to spin up a reproduction instance.