### PR TITLE
feat: Custom Themes

### DIFF
--- a/.changeset/tender-houses-enjoy.md
+++ b/.changeset/tender-houses-enjoy.md
@@ -1,0 +1,5 @@
+---
+"mode-watcher": patch
+---
+
+feat: Add support for custom themes

--- a/packages/mode-watcher/src/lib/index.ts
+++ b/packages/mode-watcher/src/lib/index.ts
@@ -2,10 +2,13 @@ import {
 	localStorageKey,
 	userPrefersMode,
 	systemPrefersMode,
+	themeLocalStorageKey,
 	mode,
 	setMode,
 	toggleMode,
 	resetMode,
+	setTheme,
+	theme
 } from './mode.js';
 
 export {
@@ -16,6 +19,9 @@ export {
 	userPrefersMode,
 	systemPrefersMode,
 	mode,
+	theme,
+	setTheme,
+	themeLocalStorageKey
 };
 
 export { default as ModeWatcher } from './mode-watcher.svelte';

--- a/packages/mode-watcher/src/lib/mode-watcher.svelte
+++ b/packages/mode-watcher/src/lib/mode-watcher.svelte
@@ -25,6 +25,7 @@
 	export let disableTransitions = true;
 	export let darkClassNames: string[] = ['dark'];
 	export let lightClassNames: string[] = [];
+	export let defaultTheme: string | undefined = 'money';
 	export let nonce: string = '';
 
 	themeColorsStore.set(themeColors);
@@ -51,7 +52,7 @@
 
 	const args = `"${defaultMode}"${
 		themeColors ? `, ${JSON.stringify(themeColors)}` : ', undefined'
-	}, ${JSON.stringify(darkClassNames)}, ${JSON.stringify(lightClassNames)}`;
+	}, ${JSON.stringify(darkClassNames)}, ${JSON.stringify(lightClassNames)}, "${defaultTheme}"`;
 
 	$: trueNonce = typeof window === 'undefined' ? nonce : '';
 </script>

--- a/packages/mode-watcher/src/lib/mode.ts
+++ b/packages/mode-watcher/src/lib/mode.ts
@@ -1,11 +1,14 @@
 import { get } from 'svelte/store';
 import {
-	localStorageKey,
+	modeLocalStorageKey,
 	userPrefersMode,
 	systemPrefersMode,
 	derivedMode,
 	themeColors,
+	theme as themeStore,
 	disableTransitions,
+	derivedTheme,
+	themeLocalStorageKey
 } from './stores.js';
 import type { Mode, ThemeColors } from './types.js';
 
@@ -24,15 +27,23 @@ export function resetMode(): void {
 	userPrefersMode.set('system');
 }
 
+/** Set the theme to a custom value */
+export function setTheme(theme: string): void {
+	themeStore.set(theme)
+}
+
+
 /** Used to set the mode on initial page load to prevent FOUC */
 export function setInitialMode(
 	defaultMode: Mode,
 	themeColors?: ThemeColors,
 	darkClassNames: string[] = ['dark'],
-	lightClassNames: string[] = []
+	lightClassNames: string[] = [],
+	defaultTheme: string = '',
 ) {
 	const rootEl = document.documentElement;
 	const mode = localStorage.getItem('mode-watcher-mode') || defaultMode;
+	const theme = localStorage.getItem('mode-watcher-theme') || defaultTheme
 	const light =
 		mode === 'light' ||
 		(mode === 'system' && window.matchMedia('(prefers-color-scheme: light)').matches);
@@ -52,11 +63,18 @@ export function setInitialMode(
 		}
 	}
 
+	if (theme) {
+		rootEl.setAttribute('data-theme', theme)
+		localStorage.setItem('mode-watcher-theme', theme)
+	}
+
 	localStorage.setItem('mode-watcher-mode', mode);
 }
 
 export {
-	localStorageKey,
+	modeLocalStorageKey as localStorageKey,
+	themeLocalStorageKey,
+	derivedTheme as theme,
 	userPrefersMode,
 	systemPrefersMode,
 	derivedMode as mode,

--- a/packages/mode-watcher/src/lib/types.ts
+++ b/packages/mode-watcher/src/lib/types.ts
@@ -20,6 +20,19 @@ export type ModeWatcherProps = {
 	defaultMode?: Mode;
 
 	/**
+	 * The default theme to use, which will be applied to the root `html` element
+	 * and can be managed with the `setTheme` function.
+	 *
+	 * @example
+	 * ```html
+	 * <html data-theme="your-custom-theme"></html>
+	 * ```
+	 *
+	 * @defaultValue `undefined`
+	 */
+	defaultTheme?: string;
+
+	/**
 	 * The theme colors to use for each mode.
 	 */
 	themeColors?: ThemeColors;

--- a/sites/docs/content/api-reference/mode-watcher.md
+++ b/sites/docs/content/api-reference/mode-watcher.md
@@ -41,9 +41,17 @@ To set a default mode, use the `defaultMode` prop:
 <ModeWatcher defaultMode="dark" />
 ```
 
+### Themes
+
+In addition to the `dark`, `light`, and `system` modes, `ModeWatcher` can also be configured with a theme which will be applied to the root `html` element like so:
+
+```html
+<html data-theme="your-custom-theme"></html>
+```
+
 ### Theme Colors
 
-`ModeWatcher` can manage the theme-color meta tag for you.
+`ModeWatcher` can manage the `theme-color` meta tag for you.
 
 To enable this, set the `themeColors` prop to your preferred colors:
 
@@ -76,7 +84,6 @@ The `ModeWatcher` component accepts the following props:
 ```ts
 export type Mode = "system" | "dark" | "light";
 export type ThemeColors = { dark: string; light: string };
-
 export type ModeWatcherProps = {
 	/**
 	 * Whether to automatically track operating system preferences
@@ -94,6 +101,19 @@ export type ModeWatcherProps = {
 	defaultMode?: Mode;
 
 	/**
+	 * The default theme to use, which will be applied to the root `html` element
+	 * and can be managed with the `setTheme` function.
+	 *
+	 * @example
+	 * ```html
+	 * <html data-theme="your-custom-theme"></html>
+	 * ```
+	 *
+	 * @defaultValue `undefined`
+	 */
+	defaultTheme?: string;
+
+	/**
 	 * The theme colors to use for each mode.
 	 *
 	 * @defaultValue `undefined`
@@ -101,7 +121,7 @@ export type ModeWatcherProps = {
 	themeColors?: ThemeColors;
 
 	/**
-	 * Whether to disable transitions when the mode changes.
+	 * Whether to disable transitions when updating the mode.
 	 *
 	 * @defaultValue `true`
 	 */
@@ -120,5 +140,14 @@ export type ModeWatcherProps = {
 	 * @defaultValue `[]`
 	 */
 	lightClassNames?: string[];
+
+	/**
+	 * An optional nonce to use for the injected script tag to allow-list mode-watcher
+	 * if you are using a Content Security Policy.
+	 *
+	 * @defaultValue `undefined`
+	 */
+	nonce?: string;
 };
+
 ```

--- a/sites/docs/content/api-reference/set-theme.md
+++ b/sites/docs/content/api-reference/set-theme.md
@@ -1,0 +1,20 @@
+---
+title: setTheme
+description: Programatically set the custom theme.
+tagline: API Reference
+---
+
+A function that sets the current custom theme, not to be confused with [`setMode`](/docs/api-reference/set-mode), which sets the mode (`'light'`, `'dark'` or `'system'`).
+
+The theme can be set to any arbitrary string value, and is persisted to localStorage and applied to the root `html` element via the `data-theme` attribute.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { setTheme } from "mode-watcher";
+</script>
+
+<button on:click={() => setTheme("dracula")}>Dracula Theme</button>
+<button on:click={() => setTheme("retro")}>Retro Theme</button>
+```

--- a/sites/docs/content/api-reference/theme-local-storage-key.md
+++ b/sites/docs/content/api-reference/theme-local-storage-key.md
@@ -1,0 +1,28 @@
+---
+title: themeLocalStorageKey
+description: The key used to store the theme in local storage.
+tagline: API Reference
+---
+
+<script>
+	import { Callout } from '$lib/components'
+</script>
+
+The key used to store the _theme_ in local storage.
+
+## Usage
+
+If you wanted to clear the history of the user's theme preference, you could use the `themeLocalStorageKey` like so:
+
+```svelte
+<script lang="ts">
+	import { themeLocalStorageKey } from "mode-watcher";
+
+	function clearThemeFromLocalStorage() {
+		localStorage.removeItem(themeLocalStorageKey);
+	}
+</script>
+
+<p>Clear the user's mode preference history.</p>
+<button on:click={clearModeFromLocalStorage}>Clear</button>
+```

--- a/sites/docs/content/api-reference/theme.md
+++ b/sites/docs/content/api-reference/theme.md
@@ -1,0 +1,25 @@
+---
+title: theme
+description: A store for tracking the current theme.
+tagline: API Reference
+---
+
+A readable store that contains the current theme, not to be confused with [`mode`](/docs/api-reference/mode), which contains the current mode (`'light'`, `'dark'` or `'system'`). The theme can be any arbitrary string value set by the developer, and can be used in conjunction with `mode` to create a custom theme switcher, similar to [Daisy UI](https://daisyui.com)'s.
+
+## Usage
+
+```svelte
+<script lang="ts">
+	import { setTheme, theme } from "mode-watcher";
+
+	function cycleTheme() {
+		if ($theme === 'dracula') {
+			setTheme('retro')
+		} else {
+			setTheme('dracula')
+		}
+	}
+</script>
+
+<button on:click={cycleTheme}>{$theme}</button>
+```

--- a/sites/docs/src/lib/config/navigation.ts
+++ b/sites/docs/src/lib/config/navigation.ts
@@ -95,6 +95,21 @@ export const navigation: Navigation = {
 					href: "/docs/api-reference/local-storage-key",
 					items: [],
 				},
+				{
+					title: 'setTheme',
+					href: '/docs/api-reference/set-theme',
+					items: []
+				},
+				{
+					title: 'theme',
+					href: '/docs/api-reference/theme',
+					items: []
+				},
+				{
+					title: 'themeLocalStorageKey',
+					href: '/docs/api-reference/theme-local-storage-key',
+					items: []
+				}
 			],
 		},
 	],


### PR DESCRIPTION
This PR introduces the ability for Mode Watcher to track custom themes, which are persisted to local storage alongside the `mode` and are applied to the root element via the `data-theme` attribute.


You can set a default theme like so:

```svelte
<ModeWatcher defaultTheme="dracula" />
```

and the rendered html will look like this:

```html
<html data-theme="dracula">
```

---

You can programatically set a theme using the `setTheme` function:

```svelte
<script>
	import { setTheme } from 'mode-watcher'
</script>

<span>Select a theme</span>
<button on:click={() => setTheme('retro')}>Retro</button>
<button on:click={() => setTheme('dracula')}>Dracula</button>
<button on:click={() => setTheme('usa')}>Red, White, and Blue</button>
```

Closes: #66 