### PR TITLE
feat: support shadow dom

### DIFF
--- a/packages/mode-watcher/src/lib/mode-watcher-full.svelte
+++ b/packages/mode-watcher/src/lib/mode-watcher-full.svelte
@@ -5,6 +5,8 @@
 	export let trueNonce: string = "";
 	export let initConfig: Parameters<typeof setInitialMode>[0];
 	export let themeColors: ThemeColors = undefined;
+
+	$: window.__modeWatcherTo = initConfig.to;
 </script>
 
 <svelte:head>

--- a/packages/mode-watcher/src/lib/mode-watcher.svelte
+++ b/packages/mode-watcher/src/lib/mode-watcher.svelte
@@ -35,6 +35,7 @@
 	export let themeStorageKey: string = "mode-watcher-theme";
 	export let modeStorageKey: string = "mode-watcher-mode";
 	export let disableHeadScriptInjection = false;
+	export let to: ModeWatcherProps["to"] = document.documentElement;
 
 	$: disableTransitionsStore.set(disableTransitions);
 	$: themeColorsStore.set(themeColors);
@@ -67,6 +68,7 @@
 		defaultTheme,
 		modeStorageKey,
 		themeStorageKey,
+		to,
 	});
 
 	$: trueNonce = typeof window === "undefined" ? nonce : "";

--- a/packages/mode-watcher/src/lib/mode.ts
+++ b/packages/mode-watcher/src/lib/mode.ts
@@ -44,7 +44,14 @@ type SetInitialModeArgs = {
 	defaultTheme?: string;
 	modeStorageKey?: string;
 	themeStorageKey?: string;
+	to?: HTMLElement | HTMLHtmlElement | null;
 };
+
+declare global {
+	interface Window {
+		__modeWatcherTo?: HTMLElement | HTMLHtmlElement | null;
+	}
+}
 
 /** Used to set the mode on initial page load to prevent FOUC */
 export function setInitialMode({
@@ -56,7 +63,7 @@ export function setInitialMode({
 	modeStorageKey = "mode-watcher-mode",
 	themeStorageKey = "mode-watcher-theme",
 }: SetInitialModeArgs) {
-	const rootEl = document.documentElement;
+	const rootEl = window.__modeWatcherTo ?? document.documentElement;
 	const mode = localStorage.getItem(modeStorageKey) || defaultMode;
 	const theme = localStorage.getItem(themeStorageKey) || defaultTheme;
 	const light =

--- a/packages/mode-watcher/src/lib/stores.ts
+++ b/packages/mode-watcher/src/lib/stores.ts
@@ -208,7 +208,7 @@ function createDerivedMode() {
 			const sanitizedLightClassNames = sanitizeClassNames($lightClassNames);
 
 			function update() {
-				const htmlEl = document.documentElement;
+				const htmlEl = window.__modeWatcherTo ?? document.documentElement;
 				const themeColorEl = document.querySelector('meta[name="theme-color"]');
 				if (derivedMode === "light") {
 					if (sanitizedDarkClassNames.length)
@@ -251,7 +251,7 @@ function createDerivedTheme() {
 		if (!isBrowser) return undefined;
 
 		function update() {
-			const htmlEl = document.documentElement;
+			const htmlEl = window.__modeWatcherTo ?? document.documentElement;
 			htmlEl.setAttribute("data-theme", $theme);
 		}
 

--- a/packages/mode-watcher/src/lib/types.ts
+++ b/packages/mode-watcher/src/lib/types.ts
@@ -71,6 +71,13 @@ export type ModeWatcherProps = {
 	themeStorageKey?: string;
 
 	/**
+	 * The element to apply the mode to.
+	 *
+	 * @defaultValue `document.documentElement`
+	 */
+	to?: HTMLElement | HTMLHtmlElement | null;
+
+	/**
 	 * An optional nonce to use for the injected script tag to allow-list mode-watcher
 	 * if you are using a Content Security Policy.
 	 *


### PR DESCRIPTION
close https://github.com/svecosystem/mode-watcher/issues/104

https://github.com/svecosystem/mode-watcher/blob/5021963a3841de36cda7dfc28919a9a9afa4469e/packages/mode-watcher/src/lib/mode-watcher-full.svelte#L18

I want to confirm why we need to use script injection to execute the setInitialMode function. What problems would arise if it were executed directly in the <script>? Currently, I am using `window.__modeWatcherTo` to store when implementing to portal, which is a bad practice, but I am unclear about the reason for injecting the script before, as [the related issue](https://github.com/rxliuli/mode-watcher/issues/89) has also been deleted.
<img width="816" alt="image" src="https://github.com/user-attachments/assets/f3d22a7c-febc-4484-a54b-a35133aee9ff" />
