### PR TITLE
fix: ensure window.matchMedia is defined as function

### DIFF
--- a/.changeset/silly-rooms-care.md
+++ b/.changeset/silly-rooms-care.md
@@ -1,0 +1,5 @@
+---
+"mode-watcher": patch
+---
+
+fix: `window.matchMedia` is not defined as function

--- a/.changeset/silly-rooms-care.md
+++ b/.changeset/silly-rooms-care.md
@@ -2,4 +2,4 @@
 "mode-watcher": patch
 ---
 
-fix: `window.matchMedia` is not defined as function
+fix: ensure `window.matchMedia` is defined as function before calling

--- a/packages/mode-watcher/src/lib/mode-states.svelte.ts
+++ b/packages/mode-watcher/src/lib/mode-states.svelte.ts
@@ -55,7 +55,7 @@ export class SystemPrefersMode {
 	#track = true;
 	#current = $state<SystemModeValue>(this.#defaultValue);
 	#mediaQueryState =
-		typeof window !== "undefined" && "matchMedia" in window
+		typeof window !== "undefined" && typeof window.matchMedia === "function"
 			? new MediaQuery("prefers-color-scheme: light")
 			: { current: false };
 


### PR DESCRIPTION
Following up on https://github.com/svecosystem/mode-watcher/issues/119#issuecomment-2813965350. https://github.com/svecosystem/mode-watcher/pull/120 didn't seem to do the trick, at least in my test environment, but checking that matchMedia is a function does.

